### PR TITLE
think outside the box的翻译问题

### DIFF
--- a/content/关于作者.md
+++ b/content/关于作者.md
@@ -7,7 +7,7 @@
 作者 Peter Kim 从事信息安全行业超过14年，在渗透测试/红队领域工作超过12年。
 他曾服务于多家公用事业公司、财富1000娱乐公司、政府机构以及大型金融机构。虽然他最为知名的是<The Hacker Playbook>一书系列，但他却热衷于建立一个“安全”的安全社区，指导学生并培训他人。他创立并维护着南加州最大的一家技术安全俱乐部“LETHAL”（www.meetup.com/LETHAL ），并在他的网站 LETHAL Security（lethalsecurity.com）进行私人培训，同时他还经营一家渗透测试公司，名为Secure Planet（www.SecurePla.net）。
  
-Peter 在他的《The Hacker Playbook》系列的主要目标是向读者灌输激情，让他们站在盒子外思考。随着安全环境不断变化，他希望帮助下一代人建立专业的安全知识和素养。
+Peter 在他的《The Hacker Playbook》系列的主要目标是向读者灌输激情，让他们跳出思维定式。随着安全环境不断变化，他希望帮助下一代人建立专业的安全知识和素养。
 
 如有以下任何一种情况，请随时联系 Peter Kim：
 - 关于这本书的问题：book@thehackerplaybook.com


### PR DESCRIPTION
think outside the box 不应该被直译成站在盒子外思考，“跳出思维定式”应该更准确一点